### PR TITLE
Slightly refactor compile.jl

### DIFF
--- a/test/standalone-aot/standalone-exe/compile.jl
+++ b/test/standalone-aot/standalone-exe/compile.jl
@@ -1,19 +1,19 @@
 include("../IRGen.jl")
 using .IRGen
-    
+
 twox(x) = 2x
-native = irgen(twox, Tuple{Int})
-dump_native(native, "libtwox.o")
-run(`clang -shared -fpic libtwox.o -o libtwox.so`)
-dir = @__DIR__
-run(`clang -c -std=gnu99 -I'../../../usr/include/julia' -DJULIA_ENABLE_THREADING=1 -fPIC twox.c`)
-run(`clang -o twox twox.o -L$dir -L$dir/../../../usr/lib -Wl,--unresolved-symbols=ignore-in-object-files -Wl,-rpath,'.' -Wl,-rpath,'../../../usr/lib' -ljulia-debug -ltwox`)
-
-
 arraysum(x) = sum([x, 1])
-native = irgen(arraysum, Tuple{Int})
-dump_native(native, "libarraysum.o")
-run(`clang -shared -fpic libarraysum.o -o libarraysum.so`)
-dir = @__DIR__
-run(`clang -c -std=gnu99 -I'../../../usr/include/julia' -DJULIA_ENABLE_THREADING=1 -fPIC arraysum.c`)
-run(`clang -o arraysum arraysum.o -L$dir -L$dir/../../../usr/lib -Wl,--unresolved-symbols=ignore-in-object-files -Wl,-rpath,'.' -Wl,-rpath,'../../../usr/lib' -ljulia-debug -larraysum`)
+
+funcs = [
+    "twox" => (twox, Tuple{Int}),
+    "arraysum" => (arraysum, Tuple{Int}),
+]
+
+for (fname, (func, sig)) in funcs
+    native = irgen(func, sig)
+    dump_native(native, "lib$fname.o")
+    run(`clang -shared -fpic lib$fname.o -o lib$fname.so`)
+    dir = @__DIR__
+    run(`clang -c -std=gnu99 -I'../../../usr/include/julia' -DJULIA_ENABLE_THREADING=1 -fPIC $fname.c`)
+    run(`clang -o $fname $fname.o -L$dir -L$dir/../../../usr/lib -Wl,--unresolved-symbols=ignore-in-object-files -Wl,-rpath,'.' -Wl,-rpath,'../../../usr/lib' -ljulia-debug -l$fname`)
+end


### PR DESCRIPTION
Alternatively, we could refactor `runtests.jl` to compile each function in it into a native .so and executable, which would make it possible to use Julia's testing infrastructure. Let me know if you'd prefer I do that instead.